### PR TITLE
WEB-10941: Fix ERN 4.3 parsing failure when ResourceId is nested under SoundRecordingEdition

### DIFF
--- a/examples/_ddex/43.xml
+++ b/examples/_ddex/43.xml
@@ -36,9 +36,19 @@
         <SoundRecording>
             <ResourceReference>A0</ResourceReference>
             <Type>Unknown</Type>
-            <ResourceId>
-                <ISRC>XXX000000000</ISRC>
-            </ResourceId>
+            <SoundRecordingEdition>
+                <Type>NonImmersiveEdition</Type>
+                <ResourceId>
+                    <ISRC>XXX000000000</ISRC>
+                </ResourceId>
+                <PLine>
+                    <Year>2024</Year>
+                    <PLineText>2024 Lickd</PLineText>
+                </PLine>
+                <TechnicalDetails>
+                    <TechnicalResourceDetailsReference>T0</TechnicalResourceDetailsReference>
+                </TechnicalDetails>
+            </SoundRecordingEdition>
             <DisplayTitleText>Test Track</DisplayTitleText>
             <DisplayTitle>
                 <TitleText>Test Track</TitleText>

--- a/src/parser/ddex/ern/43/index.ts
+++ b/src/parser/ddex/ern/43/index.ts
@@ -8,11 +8,16 @@ import { parsePurgeReleaseMessage } from "../411/elements/purgeReleaseMessage";
 // by the 4.1.1 parsers, which only read the fields they know about. The
 // version tag on the returned envelope is rewritten to ERN_43 so downstream
 // converters can route correctly.
+//
+// However, ERN 4.3 relocated a handful of fields into a SoundRecordingEdition
+// wrapper inside SoundRecording (ResourceId, PLine, TechnicalDetails). The
+// 4.1.1 parser expects those at SoundRecording level, so we normalise the
+// parsed object tree before delegating.
 export const parse43 = (action: string, object: any): Ern43.Ern => {
   switch (action) {
     case "NewReleaseMessage":
       return {
-        ...parseNewReleaseMessage(object),
+        ...parseNewReleaseMessage(normaliseSoundRecordingEditions(object)),
         version: ErnVersions.ERN_43,
         action: Ern43.Actions.NEW_RELEASE_MESSAGE,
       };
@@ -30,4 +35,38 @@ export const parse43 = (action: string, object: any): Ern43.Ern => {
     action,
     message: "unknown/unsupported action",
   });
+};
+
+const LIFTED_FIELDS = ["ResourceId", "PLine", "TechnicalDetails"] as const;
+
+const normaliseSoundRecordingEditions = (object: any): any => {
+  const soundRecordings = object?.ResourceList?.[0]?.SoundRecording;
+
+  if (!Array.isArray(soundRecordings)) {
+    return object;
+  }
+
+  for (const soundRecording of soundRecordings) {
+    const editions = soundRecording?.SoundRecordingEdition;
+
+    if (!Array.isArray(editions)) {
+      continue;
+    }
+
+    for (const field of LIFTED_FIELDS) {
+      const lifted: any[] = [];
+
+      for (const edition of editions) {
+        if (Array.isArray(edition[field])) {
+          lifted.push(...edition[field]);
+        }
+      }
+
+      if (lifted.length > 0 && !soundRecording[field]) {
+        soundRecording[field] = lifted;
+      }
+    }
+  }
+
+  return object;
 };

--- a/test/assertions.ts
+++ b/test/assertions.ts
@@ -31,4 +31,24 @@ export const assert43 = (ern: Erns) => {
   assert.exists(ern.element);
   assert.isNotEmpty(ern.element);
   assert.isObject(ern.element);
+
+  const element = (ern as Ern43.ErnNewReleaseMessage).element;
+  const soundRecording = element.resourceList.soundRecording?.[0];
+
+  assert.exists(soundRecording, "expected sound recording to be parsed");
+  assert.lengthOf(
+    soundRecording!.resourceId,
+    1,
+    "expected ResourceId to be lifted from SoundRecordingEdition",
+  );
+  assert.lengthOf(
+    soundRecording!.pLine!,
+    1,
+    "expected PLine to be lifted from SoundRecordingEdition",
+  );
+  assert.lengthOf(
+    soundRecording!.technicalDetails!,
+    1,
+    "expected TechnicalDetails to be lifted from SoundRecordingEdition",
+  );
 };


### PR DESCRIPTION
Closes WEB-10941