### PR TITLE
Bump version to 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lickd/distributions",
-      "version": "0.18.1",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lickd/logger": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Distributions parser",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump package version from 0.19.0 to 0.20.0 ahead of release

## Test plan
- [ ] Merge, then create a GitHub Release tagged `v0.20.0` to trigger the publish workflow
- [ ] Confirm `@lickd/distributions@0.20.0` appears on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)