### PR TITLE
Lift DeliveryFile fields onto TechnicalDetails when parsing ERN 4.3

### DIFF
--- a/examples/_ddex/43.xml
+++ b/examples/_ddex/43.xml
@@ -47,6 +47,24 @@
                 </PLine>
                 <TechnicalDetails>
                     <TechnicalResourceDetailsReference>T0</TechnicalResourceDetailsReference>
+                    <DeliveryFile>
+                        <Type>AudioFile</Type>
+                        <AudioCodecType>MP3</AudioCodecType>
+                        <BitRate UnitOfMeasure="kbps">320</BitRate>
+                        <NumberOfChannels>2</NumberOfChannels>
+                        <SamplingRate UnitOfMeasure="kHz">44.1</SamplingRate>
+                        <BitsPerSample>16</BitsPerSample>
+                        <File>
+                            <URI>resources/A0.mp3</URI>
+                            <HashSum>
+                                <Algorithm>MD5</Algorithm>
+                                <HashSumValue>00000000000000000000000000000000</HashSumValue>
+                            </HashSum>
+                            <FileSize>1024</FileSize>
+                        </File>
+                        <IsProvidedInDelivery>true</IsProvidedInDelivery>
+                    </DeliveryFile>
+                    <IsClip>false</IsClip>
                 </TechnicalDetails>
             </SoundRecordingEdition>
             <DisplayTitleText>Test Track</DisplayTitleText>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lickd/distributions",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lickd/logger": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Distributions parser",
   "repository": {
     "type": "git",

--- a/src/parser/ddex/ern/43/index.ts
+++ b/src/parser/ddex/ern/43/index.ts
@@ -12,12 +12,14 @@ import { parsePurgeReleaseMessage } from "../411/elements/purgeReleaseMessage";
 // However, ERN 4.3 relocated a handful of fields into a SoundRecordingEdition
 // wrapper inside SoundRecording (ResourceId, PLine, TechnicalDetails). The
 // 4.1.1 parser expects those at SoundRecording level, so we normalise the
-// parsed object tree before delegating.
+// parsed object tree before delegating. ERN 4.3 also wraps the technical
+// audio fields (File, AudioCodecType, BitRate, etc.) inside a DeliveryFile
+// element under TechnicalDetails; we flatten those back up too.
 export const parse43 = (action: string, object: any): Ern43.Ern => {
   switch (action) {
     case "NewReleaseMessage":
       return {
-        ...parseNewReleaseMessage(normaliseSoundRecordingEditions(object)),
+        ...parseNewReleaseMessage(normaliseSoundRecordings(object)),
         version: ErnVersions.ERN_43,
         action: Ern43.Actions.NEW_RELEASE_MESSAGE,
       };
@@ -37,9 +39,28 @@ export const parse43 = (action: string, object: any): Ern43.Ern => {
   });
 };
 
-const LIFTED_FIELDS = ["ResourceId", "PLine", "TechnicalDetails"] as const;
+const LIFTED_EDITION_FIELDS = [
+  "ResourceId",
+  "PLine",
+  "TechnicalDetails",
+] as const;
 
-const normaliseSoundRecordingEditions = (object: any): any => {
+const LIFTED_DELIVERY_FILE_FIELDS = [
+  "AudioCodecType",
+  "BitRate",
+  "OriginalBitRate",
+  "NumberOfChannels",
+  "SamplingRate",
+  "OriginalSamplingRate",
+  "BitsPerSample",
+  "Duration",
+  "BitDepth",
+  "File",
+  "Fingerprint",
+  "IsProvidedInDelivery",
+] as const;
+
+const normaliseSoundRecordings = (object: any): any => {
   const soundRecordings = object?.ResourceList?.[0]?.SoundRecording;
 
   if (!Array.isArray(soundRecordings)) {
@@ -47,26 +68,59 @@ const normaliseSoundRecordingEditions = (object: any): any => {
   }
 
   for (const soundRecording of soundRecordings) {
-    const editions = soundRecording?.SoundRecordingEdition;
-
-    if (!Array.isArray(editions)) {
-      continue;
-    }
-
-    for (const field of LIFTED_FIELDS) {
-      const lifted: any[] = [];
-
-      for (const edition of editions) {
-        if (Array.isArray(edition[field])) {
-          lifted.push(...edition[field]);
-        }
-      }
-
-      if (lifted.length > 0 && !soundRecording[field]) {
-        soundRecording[field] = lifted;
-      }
-    }
+    liftEditionFields(soundRecording);
+    liftDeliveryFileFields(soundRecording);
   }
 
   return object;
+};
+
+const liftEditionFields = (soundRecording: any): void => {
+  const editions = soundRecording?.SoundRecordingEdition;
+
+  if (!Array.isArray(editions)) {
+    return;
+  }
+
+  for (const field of LIFTED_EDITION_FIELDS) {
+    const lifted: any[] = [];
+
+    for (const edition of editions) {
+      if (Array.isArray(edition[field])) {
+        lifted.push(...edition[field]);
+      }
+    }
+
+    if (lifted.length > 0 && !soundRecording[field]) {
+      soundRecording[field] = lifted;
+    }
+  }
+};
+
+// The 4.1.1 parser reads File/AudioCodecType/etc. directly off TechnicalDetails.
+// In 4.3 they live inside DeliveryFile, so merge the first DeliveryFile's fields
+// up onto TechnicalDetails. Multiple DeliveryFile entries per TechnicalDetails
+// are not currently supported by the 4.1.1 shim.
+const liftDeliveryFileFields = (soundRecording: any): void => {
+  const technicalDetails = soundRecording?.TechnicalDetails;
+
+  if (!Array.isArray(technicalDetails)) {
+    return;
+  }
+
+  for (const detail of technicalDetails) {
+    const deliveryFile = Array.isArray(detail?.DeliveryFile)
+      ? detail.DeliveryFile[0]
+      : undefined;
+
+    if (!deliveryFile) {
+      continue;
+    }
+
+    for (const field of LIFTED_DELIVERY_FILE_FIELDS) {
+      if (deliveryFile[field] !== undefined && detail[field] === undefined) {
+        detail[field] = deliveryFile[field];
+      }
+    }
+  }
 };

--- a/test/assertions.ts
+++ b/test/assertions.ts
@@ -51,4 +51,20 @@ export const assert43 = (ern: Erns) => {
     1,
     "expected TechnicalDetails to be lifted from SoundRecordingEdition",
   );
+
+  const technicalDetails = soundRecording!.technicalDetails![0];
+
+  assert.exists(
+    technicalDetails.file,
+    "expected File to be lifted from DeliveryFile",
+  );
+  assert.equal(technicalDetails.file!.uri, "resources/A0.mp3");
+  assert.exists(
+    technicalDetails.audioCodecType,
+    "expected AudioCodecType to be lifted from DeliveryFile",
+  );
+  assert.exists(
+    technicalDetails.bitRate,
+    "expected BitRate to be lifted from DeliveryFile",
+  );
 };


### PR DESCRIPTION
## Summary
- ERN 4.3 wraps File, AudioCodecType, BitRate, etc. inside a `DeliveryFile` element under `TechnicalDetails`. The 4.1.1 element parsers (which 4.3 delegates to) read these fields directly off `TechnicalDetails`, so they were silently dropped — `technicalDetails.file` came back undefined and downstream consumers skipped the sound recording entirely.
- Fix: extend the 4.3 normaliser to also hoist `DeliveryFile`'s children up onto the parent `TechnicalDetails` before delegating.
- Bumps to **0.20.1**.

Observed in the wild on Sony ERN 4.3 deliveries: `ing-app-pipeline` skipped transcoding and the API ingestion then failed with `FileNotFoundException` for the expected `…-download.mp3`.

## Test plan
- [x] `npm test` — all 34 tests pass.
- [x] Extended `assert43` to verify `file.uri`, `audioCodecType`, and `bitRate` are populated.
- [x] Manually re-parsed the Sony XML that triggered the original failure; `technicalDetails[0].file.uri` now resolves correctly.

## Notes
Multiple `DeliveryFile` entries per `TechnicalDetails` aren't yet supported — only the first is hoisted. That's fine for current SME deliveries; can extend later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)