### PR TITLE
WEB-10843: Walk ResourceGroupContentItem when normalising images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lickd/distributions",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@lickd/logger": "^0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Distributions parser",
   "repository": {
     "type": "git",

--- a/src/normaliser/ddex/ern/411/complexTypes/resourceList.ts
+++ b/src/normaliser/ddex/ern/411/complexTypes/resourceList.ts
@@ -1,24 +1,53 @@
 import { Ern411 } from "../../../../../types";
 import { normaliseImage } from "./image";
 
+type ResourceGroupLike = Pick<
+  Ern411.ResourceGroup,
+  "linkedReleaseResourceReference" | "resourceGroup" | "resourceGroupContentItem"
+>;
+
+const collectLinkedResourceReferences = (
+  group: ResourceGroupLike,
+): Ern411.LinkedReleaseResourceReference[] => {
+  const references: Ern411.LinkedReleaseResourceReference[] = [];
+
+  if (group.linkedReleaseResourceReference) {
+    references.push(...group.linkedReleaseResourceReference);
+  }
+
+  group.resourceGroupContentItem?.forEach((item) => {
+    if (item.linkedReleaseResourceReference) {
+      references.push(...item.linkedReleaseResourceReference);
+    }
+  });
+
+  group.resourceGroup?.forEach((subGroup) => {
+    references.push(...collectLinkedResourceReferences(subGroup));
+  });
+
+  return references;
+};
+
 export const normaliseResourceList = (
   resourceList: Ern411.ResourceList,
   releaseList: Ern411.ReleaseList,
 ): void => {
   const release = releaseList.release;
 
-  if (release) {
-    release.resourceGroup.linkedReleaseResourceReference?.forEach(
-      (linkedReleaseResourceReference) => {
-        const image = resourceList.image?.find(
-          (image) =>
-            image.resourceReference === linkedReleaseResourceReference.value,
-        );
-
-        if (image) {
-          normaliseImage(image, release);
-        }
-      },
-    );
+  if (!release) {
+    return;
   }
+
+  collectLinkedResourceReferences(release.resourceGroup).forEach(
+    (linkedReleaseResourceReference) => {
+      const image = resourceList.image?.find(
+        (image) =>
+          image.resourceReference === linkedReleaseResourceReference.value,
+      );
+
+      if (image) {
+        normaliseImage(image, release);
+      }
+    },
+  );
 };

--- a/test/normaliser/ddex/ern/411/complexTypes/resourceList.spec.ts
+++ b/test/normaliser/ddex/ern/411/complexTypes/resourceList.spec.ts
@@ -1,0 +1,120 @@
+import { assert } from "chai";
+import { normaliseResourceList } from "../../../../../../src/normaliser/ddex/ern/411/complexTypes/resourceList";
+import { Ern411 } from "../../../../../../src/types";
+
+const buildRelease = (resourceGroup: unknown): Ern411.Release =>
+  ({
+    releaseReference: "R0",
+    displayTitleText: [{ value: "Title" }],
+    displayTitle: [],
+    displayArtist: [
+      {
+        _attributes: { sequenceNumber: 1 },
+        artistPartyReference: "P1",
+        displayArtistRole: { value: "MainArtist" },
+      },
+    ],
+    displayArtistName: [{ value: "Artist" }],
+    releaseId: { proprietaryId: [] },
+    resourceGroup,
+  } as unknown as Ern411.Release);
+
+const buildImage = (resourceReference: string): Ern411.Image =>
+  ({
+    resourceReference,
+    type: { value: "FrontCoverImage" },
+    resourceId: [],
+    technicalDetails: [],
+  } as unknown as Ern411.Image);
+
+describe("normaliseResourceList (ern 4.1.1)", () => {
+  it("normalises images linked directly on resourceGroup", () => {
+    const image = buildImage("A2");
+
+    normaliseResourceList(
+      { image: [image] } as Ern411.ResourceList,
+      {
+        release: buildRelease({
+          linkedReleaseResourceReference: [{ value: "A2" }],
+        }),
+      } as Ern411.ReleaseList,
+    );
+
+    assert.isDefined(image.displayArtist, "displayArtist should be inherited");
+    assert.equal(image.displayArtist?.[0].artistPartyReference, "P1");
+  });
+
+  it("normalises images linked via resourceGroupContentItem", () => {
+    const image = buildImage("A2");
+
+    normaliseResourceList(
+      { image: [image] } as Ern411.ResourceList,
+      {
+        release: buildRelease({
+          resourceGroupContentItem: [
+            {
+              sequenceNumber: 1,
+              releaseResourceReference: "A1",
+              linkedReleaseResourceReference: [{ value: "A2" }],
+            },
+          ],
+        }),
+      } as Ern411.ReleaseList,
+    );
+
+    assert.isDefined(
+      image.displayArtist,
+      "displayArtist should be inherited via resourceGroupContentItem",
+    );
+    assert.equal(image.displayArtist?.[0].artistPartyReference, "P1");
+  });
+
+  it("normalises images linked via nested resourceGroup (sub-group)", () => {
+    const image = buildImage("A2");
+
+    normaliseResourceList(
+      { image: [image] } as Ern411.ResourceList,
+      {
+        release: buildRelease({
+          resourceGroup: [
+            {
+              resourceGroupContentItem: [
+                {
+                  sequenceNumber: 1,
+                  releaseResourceReference: "A1",
+                  linkedReleaseResourceReference: [{ value: "A2" }],
+                },
+              ],
+            },
+          ],
+        }),
+      } as Ern411.ReleaseList,
+    );
+
+    assert.isDefined(
+      image.displayArtist,
+      "displayArtist should be inherited via nested sub-group",
+    );
+  });
+
+  it("leaves images untouched when no link matches", () => {
+    const image = buildImage("A2");
+
+    normaliseResourceList(
+      { image: [image] } as Ern411.ResourceList,
+      {
+        release: buildRelease({
+          resourceGroupContentItem: [
+            {
+              sequenceNumber: 1,
+              releaseResourceReference: "A1",
+              linkedReleaseResourceReference: [{ value: "A9" }],
+            },
+          ],
+        }),
+      } as Ern411.ReleaseList,
+    );
+
+    assert.isUndefined(image.displayArtist);
+  });
+});


### PR DESCRIPTION
## Summary
- `normaliseResourceList` only walked `release.resourceGroup.linkedReleaseResourceReference`, but in real ERN 4.1.1 deliveries (e.g. SME `SingleResourceRelease` messages) the link to the cover-art image lives inside `resourceGroupContentItem[]` (and can nest in sub-groups). The normaliser silently iterated nothing, so `normaliseImage` never ran and images never inherited `displayArtist` / `displayTitle` from the release.
- Walk all three locations: top-level `linkedReleaseResourceReference`, `resourceGroupContentItem[].linkedReleaseResourceReference`, and recurse into nested `resourceGroup[]` sub-groups.
- Add a focused unit spec covering all three paths plus the no-match case.
- Bump to 0.20.2.

The downstream symptom in `ing-app-pipeline` was the distro Step Function crashing in `ImageArtistGet` with a `States.Format` failure on `$.image.displayArtist[0].artistPartyReference`, surfaced opaquely as `States.ExceedToleratedFailureThreshold`. Repro file: `A10301A0000585354S.xml` (Tony Bennett — Ol' Man River live).

## Test plan
- [x] `npm test` (38 passing — 4 new specs in `test/normaliser/ddex/ern/411/complexTypes/resourceList.spec.ts`)
- [ ] After merge & publish, bump `@lickd/distributions` in `ing-app-pipeline` and re-run the failed Step Functions execution