### PR TITLE
Bump version to 0.20.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lickd/distributions",
-      "version": "0.20.2",
+      "version": "0.20.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@lickd/logger": "^0.0.8",
@@ -2401,7 +2401,7 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
+      "version": "0.20.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lickd/distributions",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "Distributions parser",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Companion to #11. Bumps package.json + package-lock.json so the v0.20.3 GitHub release can actually publish to npm (the first attempt failed with E403 'You cannot publish over the previously published versions: 0.20.2').

After merge: delete the existing v0.20.3 tag + release, then recreate the release pointing at the new main HEAD to retrigger the Publish workflow.